### PR TITLE
Add syntax highlighting for fields

### DIFF
--- a/lib/vmail.vim
+++ b/lib/vmail.vim
@@ -32,6 +32,8 @@ let s:show_help_command = s:client_script . "show_help"
 
 let s:message_bufname = "MessageWindow"
 
+
+
 function! VmailStatusLine()
   return "%<%f\ " . s:mailbox . " " . s:query . "%r%=%-14.(%l,%c%V%)\ %P"
 endfunction
@@ -163,6 +165,18 @@ function! s:focus_list_window()
     " colorize whole line
     syn match VmailBufferFlagged /^*.*/hs=s
     exec "hi def VmailBufferFlagged " . g:vmail_flagged_color
+    " color each field differently.
+    syn  match  flags    "^[^|]*"  nextgroup=date
+    syn  match  date     "|[^|]*"  contained nextgroup=sender
+    syn  match  sender   "|[^|]*"  contained nextgroup=subject
+    syn  match  subject  "|[^|]*"  contained nextgroup=size
+    syn  match  size     "|[^|]*"  contained
+
+    hi def link flags    constant
+    hi def link date     question
+    hi def link sender   statement
+    hi def link subject  title
+    hi def link size     number
   endif
   " vertically center the cursor line
   " normal z.

--- a/lib/vmail/imap_client.rb
+++ b/lib/vmail/imap_client.rb
@@ -200,7 +200,7 @@ module Vmail
                    (date_formatted || '').col(14),
                    address.col(address_col_width),
                    subject.col(subject_col_width), 
-                   number_to_human_size(size).rcol(6) ].join(' ')
+                   number_to_human_size(size).rcol(6) ].join('|')
       {:uid => uid, :seqno => seqno, :row_text => row_text}
     rescue 
       log "error extracting header for uid #{uid} seqno #{seqno}: #$!"


### PR DESCRIPTION
Hi Dan,

 I'm a fan of vmail, thanks for the hard work. I wanted some highlighting, so i added some vim syntax matching groups that add highlighting for fields in the email list view.

This requires a field delimiter to be set, in this case, using '|' instead of ' ' for outputting the messages.
- okay
