### PR TITLE
Support to GMail's subfolders

### DIFF
--- a/lib/vmail/imap_client.rb
+++ b/lib/vmail/imap_client.rb
@@ -148,7 +148,7 @@ module Vmail
 
     def list_mailboxes
       log 'loading mailboxes...'
-      @mailboxes ||= ((@imap.list("[Gmail]/", "%") || []) + (@imap.list("", "%")) || []).
+      @mailboxes ||= ((@imap.list("[Gmail]/", "%") || []) + (@imap.list("", "*")) || []).
         select {|struct| struct.attr.none? {|a| a == :Noselect} }.
         map {|struct| struct.name}.
         map {|name| MailboxAliases.invert[name] || name}


### PR DESCRIPTION
GMail's subfolders have a different mailbox prefix. For example:
-- Foo
----- Bar
----- Baz

This label structure would be represented as "Foo/" "Foo/Bar" "Foo/Baz" and not "[GMail]/....."
I've changed the code to support these kind of labels.
