### PR TITLE
Own e-mail address no longer CC'ed in reply-all

### DIFF
--- a/lib/vmail/reply_templating.rb
+++ b/lib/vmail/reply_templating.rb
@@ -52,7 +52,9 @@ module Vmail
            end
       xs = xs.select {|x|
         email = (x[/<([^>]+)>/, 1] || x) 
-        email !~ /#{reply_recipient}/ && (@always_cc ? (email !~ /#{@always_cc}/) : true) 
+        email !~ /#{reply_recipient}/ \
+          && email !~ /#@username/ \
+          && (@always_cc ? (email !~ /#{@always_cc}/) : true) 
       }
       if @always_cc 
         xs << @always_cc


### PR DESCRIPTION
Filters CC list generated on reply-all so that the current user's own address doesn't get CC'ed.

Unfortunately, the test suite seems to be a refactor behind so I didn't change anything there. Let me know if there are any stylistic problems.

Fixes #64.
