### PR TITLE
Attempt to use xdg-open as a vmail browser

### DIFF
--- a/lib/vmail.rb
+++ b/lib/vmail.rb
@@ -29,7 +29,7 @@ module Vmail
 
     vim = ENV['VMAIL_VIM'] || 'vim'
     ENV['VMAIL_BROWSER'] ||= if RUBY_PLATFORM.downcase.include?('linux') 
-                               tools = ['gnome-open', 'kfmclient-exec', 'konqueror']
+                               tools = ['gnome-open', 'kfmclient-exec', 'xdg-open', 'konqueror']
                                tool = tools.detect { |tool|
                                  `which #{tool}`.size > 0
                                }


### PR DESCRIPTION
`xdg-open` is a DE-independent way to open a file with its associated program. This might help out people with minimal setups like myself.
