### PR TITLE
Fix syntax highlighting.

### DIFF
--- a/lib/vmail.vim
+++ b/lib/vmail.vim
@@ -57,6 +57,7 @@ function! s:create_list_window()
   let s:listbufname = bufname('%')
   setlocal statusline=%!VmailStatusLine()
   call s:message_list_window_mappings()
+  setlocal filetype=vmail
   autocmd BufNewFile,BufRead *.txt setlocal modifiable
 endfunction
 
@@ -823,7 +824,7 @@ func! s:message_list_window_mappings()
   noremap <silent> <buffer> <c-k> :call <SID>show_previous_message_in_list()<cr>
   nnoremap <silent> <buffer> <Space> :call <SID>toggle_maximize_window()<cr>
   autocmd CursorMoved <buffer> :redraw
-  autocmd BufEnter,BufWinEnter <buffer> :call <SID>set_list_colors()
+  autocmd FileType vmail :call <SID>set_list_colors()
 endfunc
 
 func! s:compose_window_mappings()


### PR DESCRIPTION
This diff fixes an issue that I have while displaying the message list.
The problem is that I don't have syntax highlighting enables as soon as the message list shows up.
This is due to the fact that the BufEvent is triggered before the autocmd is defined.
After I reload the buffer with an `:e` the `BufEnter` event is triggered and all is good.
This diff sets the filetype of the vmailbuffer to `vmail`, and binds the `set_list_colors()` call to the `FileType vmail` event, therefore avoiding the original race condition.
