### PR TITLE
Adding a password script option

### DIFF
--- a/lib/vmail/options.rb
+++ b/lib/vmail/options.rb
@@ -70,7 +70,11 @@ EOF
 
           @config = YAML::load(File.read(@config_file))
           if @config['password'].nil?
-            @config['password'] = ask("Enter gmail password (won't be visible & won't be persisted):") {|q| q.echo = false}
+            if @config['password_script'].nil?
+              @config['password'] = ask("Enter gmail password (won't be visible & won't be persisted):") {|q| q.echo = false}
+            else
+              @config['password'] = %x{ #{@config['password_script'].strip} }.strip
+            end
           end
 
           if @get_contacts


### PR DESCRIPTION
This allows you to specify a command to be executed in your vmailrc.
For example, in osx I am using it like this: 
`password_script: security find-internet-password -w -a islam.sharabash@gmail.com -s smtp.gmail.com`
