### PR TITLE
Adds Versionomy for more robust Ruby version check

### DIFF
--- a/lib/vmail.rb
+++ b/lib/vmail.rb
@@ -4,13 +4,16 @@ require 'vmail/query'
 require 'vmail/message_formatter'
 
 require 'iconv'
+require 'versionomy'
 
 module Vmail
   extend self
 
   def start
     puts "Starting vmail #{Vmail::VERSION}"
-    if  "1.9.0" > RUBY_VERSION
+    required_version = Versionomy::create(:major => 1, :minor => 9, :tiny => 0)
+    ruby_version = Versionomy::parse(RUBY_VERSION)
+    if required_version > ruby_version
       puts "This version of vmail requires Ruby version 1.9.0 or higher (1.9.2 is recommended)"
       exit
     end

--- a/vmail.gemspec
+++ b/vmail.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'highline', '>= 1.6.1'
   s.add_dependency 'sequel', '>= 3.24.1'
   s.add_dependency 'sqlite3', '>= 1.3.3'
+  s.add_dependency 'versionomy', '>= 0.4.4'
 end


### PR DESCRIPTION
Adds Versionomy dependency in order to account for Ruby versions that
cannot be compared with simple numeric comparison. Example 1.9.3p327

Gemspec adds dependency for Versionomy >= 0.4.0

Addresses issue from Google groups
https://groups.google.com
/forum/?hl=en&fromgroups=#!topic/vmail-users/4J3ApOOwIJc
