### PR TITLE
  Support for different sent mailbox name

### DIFF
--- a/lib/vmail/contacts_extractor.rb
+++ b/lib/vmail/contacts_extractor.rb
@@ -2,9 +2,9 @@ require 'net/imap'
 
 module Vmail
 class ContactsExtractor
-  def initialize(username, password)
+  def initialize(username, password, sent_box)
     puts "Logging as #{username}"
-    @username, @password = username, password
+    @username, @password, @sent_box = username, password, sent_box
   end
 
   def open
@@ -18,9 +18,9 @@ class ContactsExtractor
   def extract(limit = 500)
     open do |imap|
       set_mailbox_prefix
-      mailbox = "[#@prefix]/Sent Mail"
+      mailbox = "[#@prefix]/#@sent_box"
       STDERR.puts "Selecting #{mailbox}"
-      imap.select(mailbox)
+      imap.select(Net::IMAP.encode_utf7(mailbox))
       STDERR.puts "Fetching last #{limit} sent messages"
       all_uids = imap.uid_search('ALL')
       STDERR.puts "Total messages: #{all_uids.size}"

--- a/lib/vmail/options.rb
+++ b/lib/vmail/options.rb
@@ -73,9 +73,13 @@ EOF
             @config['password'] = ask("Enter gmail password (won't be visible & won't be persisted):") {|q| q.echo = false}
           end
 
+          if @config['sent_box'].nil?
+            @config['sent_box'] = 'Sent Mail'
+          end
+
           if @get_contacts
             require 'vmail/contacts_extractor'
-            extractor = ContactsExtractor.new(@config['username'], @config['password'])
+            extractor = ContactsExtractor.new(@config['username'], @config['password'], @config['sent_box'])
             File.open(DEFAULT_CONTACTS_FILENAME, 'w') do |file|
               extractor.extract(@max_messages_to_scan) do |address| 
                 STDERR.print '.'


### PR DESCRIPTION
Non-english gmail account have mailboxes with different names, in particular the sent mailbox. I have added an option "sent_box" to specify it.
