### PR TITLE
Marking messages as read produce the right message

### DIFF
--- a/lib/vmail.vim
+++ b/lib/vmail.vim
@@ -282,7 +282,7 @@ function! s:mark_as_read_unread(read) range
   setlocal nomodifiable
   write
   redraw
-  echom nummsgs  ." conversation(s) have been marked as unread."
+  echom nummsgs  ." conversation(s) have been marked as " . (a:read ? "read" : "unread") . "."
 endfunction
 
 function! s:toggle_star() range


### PR DESCRIPTION
Regarding issue #134.

Before the status messages for both marking messages as read and unread was the same.

I hope this would fix that. 

I was not able to test this though as I am not familiar with vim development at all.
