### PR TITLE
Adding 'o' key for Open/Close message window

### DIFF
--- a/lib/vmail.vim
+++ b/lib/vmail.vim
@@ -877,6 +877,7 @@ func! s:message_window_mappings()
 
   if !hasmapto('<Plug>VmailMessageWindow_CloseWindow')
     nmap <buffer> <leader>q <Plug>VmailMessageWindow_CloseWindow
+    nmap <buffer> o <Plug>VmailMessageWindow_CloseWindow
   endif
   nnoremap <buffer> <unique> <script> <Plug>VmailMessageWindow_CloseWindow :call <SID>close_message_window()<CR>
 
@@ -957,6 +958,7 @@ endfunc
 func! s:message_list_window_mappings()
   if !hasmapto('<Plug>VmailOpenMessage')
     nmap <buffer> <CR> <Plug>VmailOpenMessage
+    nmap <buffer> o <Plug>VmailOpenMessage
     nmap <buffer> <LeftMouse> <Plug>VmailOpenMessage
   endif
   nnoremap <buffer> <unique> <script> <Plug>VmailOpenMessage :call <SID>show_message(0)<CR>


### PR DESCRIPTION
So here is the thing. I consider Enter as a "too far" key (which is stressed by
my right-hand RSI). Since `o` key is unused for both message list and view
(both buffers are read-only), this patch adds Open and Close Message Window
mappings.

This is quick way of opening and closing (for consistency with Space/Enter)
messages. I like this very much and hope you will like it too.

If you are happy with the change, I will go ahead and add this mapping to the
wiki (list of keys page I suppose).

Vmail looks like my primary MUA now (happy Mutt user). I would like to help
implementing two missing things which I consider as "blockers" for me:
- Threads
- Vertical split (I have this nice super-wide panel and I want to see more)

Good stuff guys!
