### PR TITLE
Turned off sync writing

### DIFF
--- a/lib/vmail/database.rb
+++ b/lib/vmail/database.rb
@@ -15,6 +15,7 @@ if db.tables.include?(:version) &&
 else
   print "OK\n"
 end
+db.fetch('PRAGMA synchronous=OFF')
 db.disconnect
 
 if !File.size?('vmail.db')


### PR DESCRIPTION
Since the SQLite database is really a cache, this can potentially improve
writing speeds. To be honest, I was not able to measure anything. Throwing the
patch in before I leave this topic :-D
