### PR TITLE
Use array for fullnames in defaults

### DIFF
--- a/lib/vmail/defaults.rb
+++ b/lib/vmail/defaults.rb
@@ -1,13 +1,13 @@
 module Vmail
   module Defaults
     MAILBOX_ALIASES = {
-      'sent' => 'Sent Mail',
-      'all' => 'All Mail',
-      'starred' => 'Starred',
-      'important' => 'Important',
-      'drafts' => 'Drafts',
-      'spam' => 'Spam',
-      'trash' => 'Trash'
+      'sent' => ['Sent Mail'],
+      'all' => ['All Mail'],
+      'starred' => ['Starred'],
+      'important' => ['Important'],
+      'drafts' => ['Drafts'],
+      'spam' => ['Spam'],
+      'trash' => ['Trash', 'Bin']
     }
   end
 end

--- a/lib/vmail/imap_client.rb
+++ b/lib/vmail/imap_client.rb
@@ -179,10 +179,12 @@ module Vmail
     def mailbox_aliases
       return @mailbox_aliases if @mailbox_aliases
       @mailbox_aliases = {}
-      @default_mailbox_aliases.each do |shortname, fullname|
-        [ "[Gmail]", "[Google Mail]" ].each do |prefix|
-          if self.mailboxes.include?( "#{prefix}/#{fullname}" )
-            @mailbox_aliases[shortname] =  "#{prefix}/#{fullname}"
+      @default_mailbox_aliases.each do |shortname, fullname_list|
+        fullname_list.each do |fullname|
+          [ "[Gmail]", "[Google Mail]" ].each do |prefix|
+            if self.mailboxes.include?( "#{prefix}/#{fullname}" )
+              @mailbox_aliases[shortname] =  "#{prefix}/#{fullname}"
+            end
           end
         end
       end


### PR DESCRIPTION
I'm also faced with issue #155 , and looks like a culprit in my case is  the difference in the full names ([Gmail]/Trash vs [Gmail]/Bin). Probably, it will be better to have multiple options for a possible fullname in the Default module?