### PR TITLE
Add icon to new mail notifications in Linux

### DIFF
--- a/lib/vmail/inbox_poller.rb
+++ b/lib/vmail/inbox_poller.rb
@@ -11,7 +11,7 @@ module Vmail
         log "Using notify tool: #{ n }"
         @notifier = case n
           when /notify-send/
-            Proc.new {|t, m| `#{ n } -t 6000000 '#{ t }' '#{ m }'` }
+            Proc.new {|t, m| `#{ n } -t 6000000 -i mail_new '#{ t }' '#{ m }'` }
           when /growlnotify/
             Proc.new {|t, m| `#{ n } -t '#{ t }' -m '#{ m }'` }
           end


### PR DESCRIPTION
![](http://i.imgur.com/OUpJazQ.png)

Just adds an icon to notifications on Linux for new mail. `mail-new` is a generic icon and will use the icon from the currently used theme. If it can't find a `mail-new` icon, it'll just notify without an icon.
