### PR TITLE
add def has_clientserver? & def vim from vmail.rb

### DIFF
--- a/lib/vmail/imap_client.rb
+++ b/lib/vmail/imap_client.rb
@@ -206,6 +206,14 @@ module Vmail
       self.max_seqno -= num
     end
 
+    def has_clientserver?
+      @has_clientserver ||= system("#{ vim } --version | grep +clientserver")
+    end
+
+    def vim
+      ENV['VMAIL_VIM'] || 'vim'
+    end
+
     def check_for_new_messages
       log "Checking for new messages"
       if search_query?


### PR DESCRIPTION
This is a pull request in response to issue https://github.com/danchoi/vmail/issues/209.
After applying the solution suggested by @PedroLopes, 
updating now works for me on mac osx with the following specs:
VIM - Vi IMproved 8.0 (2016 Sep 12, compiled Jul 26 2017 19:10:24)
vmail 2.9.8 (from gem)

It may be preferable to use the `habpy` version of vmail (which I believe arose from issue https://github.com/danchoi/vmail/issues/199), as @PedroLopes suggested, but I think the solution in this pull request is the simplest and cleanest fix.
  
  