### PR TITLE
Fix Matrix Notifications (charset=utf8)

### DIFF
--- a/lib/vmail/showing_message.rb
+++ b/lib/vmail/showing_message.rb
@@ -70,7 +70,7 @@ module Vmail
       # [\w-]+ matches charsets like ISO-8851
       if /charset=([\w-]+)/.match(parts_list)
         conv_from = /charset=([\w-]+)/.match(parts_list)[1].strip
-        unless conv_from = 'utf8' or conv_from = 'UTF-8'
+        unless conv_from == 'utf8' or conv_from == 'UTF-8'
           body = body.encode!('utf-8', conv_from, undef: :replace, invalid: :replace)
         end
       else

--- a/lib/vmail/showing_message.rb
+++ b/lib/vmail/showing_message.rb
@@ -70,7 +70,9 @@ module Vmail
       # [\w-]+ matches charsets like ISO-8851
       if /charset=([\w-]+)/.match(parts_list)
         conv_from = /charset=([\w-]+)/.match(parts_list)[1].strip
-        body = body.encode!('utf-8', conv_from, undef: :replace, invalid: :replace)
+        unless conv_from = 'utf8' or conv_from = 'UTF-8'
+          body = body.encode!('utf-8', conv_from, undef: :replace, invalid: :replace)
+        end
       else
         body = body.encode!('us-ascii', 'utf-8', undef: :replace, invalid: :replace)
       end


### PR DESCRIPTION
```
From: Matrix Notifications <noreply@notifs.matrix.org>
...
--===============3135740482898039686==
Mime-Version: 1.0
Content-Type: text/plain;
 charset=utf8
Content-Transfer-Encoding: base64
```